### PR TITLE
Normalize relative paths from project $path entries

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1348,6 +1348,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "path-slash"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff65715a17cba8979903db6294baef56c5d39e05c8b054cffa31e69e61f24c68"
+
+[[package]]
 name = "percent-encoding"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1832,6 +1838,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7fe5bd57d1d7414c6b5ed48563a2c855d995ff777729dcd91c369ec7fea395ae"
 
 [[package]]
+name = "relative-path"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c602122c47b382cd045b10866a084b184035d45d8c2609cdd3762852ddfae2a1"
+
+[[package]]
 name = "remove_dir_all"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1946,12 +1958,14 @@ dependencies = [
  "notify",
  "opener",
  "paste",
+ "path-slash",
  "pretty_assertions",
  "rbx_binary",
  "rbx_dom_weak",
  "rbx_reflection",
  "rbx_xml",
  "regex",
+ "relative-path",
  "reqwest",
  "ritz",
  "rlua",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -87,6 +87,8 @@ termcolor = "1.0.5"
 thiserror = "1.0.11"
 tokio = "0.1.22"
 uuid = { version = "0.8.1", features = ["v4", "serde"] }
+relative-path = "1.2.1"
+path-slash = "0.1.3"
 
 [target.'cfg(windows)'.dependencies]
 winreg = "0.6.2"

--- a/src/snapshot_middleware/snapshots/librojo__snapshot_middleware__project__test__project_with_relative_path.snap
+++ b/src/snapshot_middleware/snapshots/librojo__snapshot_middleware__project__test__project_with_relative_path.snap
@@ -1,0 +1,21 @@
+---
+source: src/snapshot_middleware/project.rs
+expression: instance_snapshot
+---
+snapshot_id: ~
+metadata:
+  ignore_unknown_instances: false
+  instigating_source:
+    Path: /foo/bar/default.project.json
+  relevant_paths:
+    - /baz/other.txt
+    - /baz/other.meta.json
+    - /foo/bar/default.project.json
+  context: {}
+name: path-project
+class_name: StringValue
+properties:
+  Value:
+    Type: String
+    Value: "Hello, world!"
+children: []


### PR DESCRIPTION
This helps to sidestep too-long path crashes on Windows when a project that is already at a deep path uses a relative $path reference. In the test case, the previous behaviour would be to attempt to access `/foo/bar/../../baz/other.txt` whereas this would now be resolved to `/baz/other.txt` before attempting any filesystem operations.