### PR TITLE
Add --no-git flag to rojo init

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 * Updated default place template to take advantage of [#210](https://github.com/Roblox/rojo/pull/210).
 * Enabled glob ignore patterns by default and removed the `unstable_glob_ignore` feature.
     * `globIgnorePaths` can be set on a project to a list of globs to ignore.
+* Added `--no-git` flag to rojo init, which initializes a project without Git
 
 ## [6.0.0 Release Candidate 1](https://github.com/Roblox/rojo/releases/tag/v6.0.0-rc.1) (March 29, 2020)
 This release jumped from 0.6.0 to 6.0.0. Rojo has been in use in production for many users for quite a long times, and so 6.0 is a more accurate reflection of Rojo's version than a pre-1.0 version.

--- a/src/cli/init.rs
+++ b/src/cli/init.rs
@@ -51,7 +51,11 @@ pub fn init(options: InitCommand) -> Result<(), anyhow::Error> {
     }
 }
 
-fn init_place(base_path: &Path, project_params: ProjectParams, no_git: bool) -> Result<(), anyhow::Error> {
+fn init_place(
+    base_path: &Path,
+    project_params: ProjectParams,
+    no_git: bool,
+) -> Result<(), anyhow::Error> {
     eprintln!("Creating new place project '{}'", project_params.name);
 
     let project_file = project_params.render_template(PLACE_PROJECT);
@@ -92,13 +96,17 @@ fn init_place(base_path: &Path, project_params: ProjectParams, no_git: bool) -> 
     if !no_git {
         try_git_init(base_path, &git_ignore)?
     }
-    
+
     eprintln!("Created project successfully.");
 
     Ok(())
 }
 
-fn init_model(base_path: &Path, project_params: ProjectParams, no_git: bool) -> Result<(), anyhow::Error> {
+fn init_model(
+    base_path: &Path,
+    project_params: ProjectParams,
+    no_git: bool,
+) -> Result<(), anyhow::Error> {
     eprintln!("Creating new model project '{}'", project_params.name);
 
     let project_file = project_params.render_template(MODEL_PROJECT);

--- a/src/cli/init.rs
+++ b/src/cli/init.rs
@@ -43,13 +43,15 @@ pub fn init(options: InitCommand) -> Result<(), anyhow::Error> {
         name: project_name.to_owned(),
     };
 
+    let no_git = options.no_git;
+
     match options.kind {
-        InitKind::Place => init_place(&base_path, project_params),
-        InitKind::Model => init_model(&base_path, project_params),
+        InitKind::Place => init_place(&base_path, project_params, no_git),
+        InitKind::Model => init_model(&base_path, project_params, no_git),
     }
 }
 
-fn init_place(base_path: &Path, project_params: ProjectParams) -> Result<(), anyhow::Error> {
+fn init_place(base_path: &Path, project_params: ProjectParams, no_git: bool) -> Result<(), anyhow::Error> {
     eprintln!("Creating new place project '{}'", project_params.name);
 
     let project_file = project_params.render_template(PLACE_PROJECT);
@@ -86,14 +88,17 @@ fn init_place(base_path: &Path, project_params: ProjectParams) -> Result<(), any
     )?;
 
     let git_ignore = project_params.render_template(PLACE_GIT_IGNORE);
-    try_git_init(base_path, &git_ignore)?;
 
+    if !no_git {
+        try_git_init(base_path, &git_ignore)?
+    }
+    
     eprintln!("Created project successfully.");
 
     Ok(())
 }
 
-fn init_model(base_path: &Path, project_params: ProjectParams) -> Result<(), anyhow::Error> {
+fn init_model(base_path: &Path, project_params: ProjectParams, no_git: bool) -> Result<(), anyhow::Error> {
     eprintln!("Creating new model project '{}'", project_params.name);
 
     let project_file = project_params.render_template(MODEL_PROJECT);
@@ -109,7 +114,10 @@ fn init_model(base_path: &Path, project_params: ProjectParams) -> Result<(), any
     write_if_not_exists(&src.join("init.lua"), &init)?;
 
     let git_ignore = project_params.render_template(MODEL_GIT_IGNORE);
-    try_git_init(base_path, &git_ignore)?;
+
+    if !no_git {
+        try_git_init(base_path, &git_ignore)?
+    }
 
     eprintln!("Created project successfully.");
 

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -128,6 +128,10 @@ pub struct InitCommand {
     /// The kind of project to create, 'place' or 'model'. Defaults to place.
     #[structopt(long, default_value = "place")]
     pub kind: InitKind,
+
+    /// Option to not initialize a Git repository in the newly created Rojo project. Defaults to false.
+    #[structopt(long)]
+    pub no_git: bool,
 }
 
 impl InitCommand {


### PR DESCRIPTION
As Kampfkarren said in #342, there should be an option to not initialize Git in `rojo init`.

This PR implements `--no-git` as an optional flag since there are some users who don't use Git as their VCS and use a different VCS or just don't want to use Git at all.